### PR TITLE
Fix double click on dots and next prev button

### DIFF
--- a/owlcarousel2-a11ylayer.js
+++ b/owlcarousel2-a11ylayer.js
@@ -72,9 +72,13 @@
           action = 'next.owl.carousel';
         }
         else if (e.keyCode == 13) {
-          if (eventTarg.hasClass('owl-prev')) action = 'prev.owl.carousel';
-          else if (eventTarg.hasClass('owl-next')) action = 'next.owl.carousel';
-          else if (eventTarg.hasClass('owl-dot')) action = 'click';
+          // In the latest version of owl carousel both dots and prev / next elements are buttons by default
+          // Check if element with getDocumentKeyUp is a button to avoid double clicks (1 by core + 1 by this plugin)
+          if (!eventTarg.is('button')) {
+            if (eventTarg.hasClass('owl-prev')) action = 'prev.owl.carousel';
+            else if (eventTarg.hasClass('owl-next')) action = 'next.owl.carousel';
+            else if (eventTarg.hasClass('owl-dot')) action = 'click';
+          }
         }
 
         if (!!action) targ.trigger(action);


### PR DESCRIPTION
In the latest version of owl carousel both dots and prev / next elements are buttons by default
Check if element with getDocumentKeyUp is a button to avoid double clicks (1 by core + 1 by this plugin)
https://github.com/OwlCarousel2/OwlCarousel2/blob/develop/src/js/owl.navigation.js#L135
https://github.com/OwlCarousel2/OwlCarousel2/blob/develop/src/js/owl.navigation.js#L181